### PR TITLE
Windows build

### DIFF
--- a/atintegrators/AperturePass.c
+++ b/atintegrators/AperturePass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 

--- a/atintegrators/BendLinearPass.c
+++ b/atintegrators/BendLinearPass.c
@@ -4,7 +4,7 @@
    A.Terebilo terebilo@ssrl.slac.stanford.edu
 */
 
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 #include "atphyslib.c"

--- a/atintegrators/BndMPoleSymplectic2RadQEPass.c
+++ b/atintegrators/BndMPoleSymplectic2RadQEPass.c
@@ -1,4 +1,5 @@
-#include "at.h"
+
+#include "atelem.c"
 #include "atlalib.c"
 #include "atphyslib.c"
 /*

--- a/atintegrators/BndMPoleSymplectic4E2Pass.c
+++ b/atintegrators/BndMPoleSymplectic4E2Pass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 #include "atphyslib.c"

--- a/atintegrators/BndMPoleSymplectic4E2RadPass.c
+++ b/atintegrators/BndMPoleSymplectic4E2RadPass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+#include "atelem.c"
 #include "atlalib.c"
 #include "atphyslib.c"
 

--- a/atintegrators/BndMPoleSymplectic4FrgFPass.c
+++ b/atintegrators/BndMPoleSymplectic4FrgFPass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 #include "atphyslib.c"		/* edge, edge_fringe */

--- a/atintegrators/BndMPoleSymplectic4FrgFRadPass.c
+++ b/atintegrators/BndMPoleSymplectic4FrgFRadPass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 #include "atphyslib.c"		/* edge, edge_fringe */

--- a/atintegrators/BndMPoleSymplectic4Pass.c
+++ b/atintegrators/BndMPoleSymplectic4Pass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+#include "atelem.c"
 #include "atlalib.c"
 #include "atphyslib.c"
 

--- a/atintegrators/BndMPoleSymplectic4RadPass.c
+++ b/atintegrators/BndMPoleSymplectic4RadPass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+#include "atelem.c"
 #include "atlalib.c"
 #include "atphyslib.c"
 

--- a/atintegrators/CavityPass.c
+++ b/atintegrators/CavityPass.c
@@ -3,7 +3,7 @@
  * Revision 3/10/04
  * A.Terebilo terebilo@ssrl.slac.stanford.edu
  */
-#include "at.h"
+
  #include "atelem.c"
 #include <math.h>
 #define TWOPI  6.28318530717959

--- a/atintegrators/CorrectorPass.c
+++ b/atintegrators/CorrectorPass.c
@@ -7,7 +7,7 @@
 */
 
 
-#include "at.h"
+
 
 
 

--- a/atintegrators/DeltaQPass.c
+++ b/atintegrators/DeltaQPass.c
@@ -1,4 +1,5 @@
-#include "at.h"
+
+#include "atelem.c"
 #include "atlalib.c"
 
 #define TWOPI		6.28318530717959

--- a/atintegrators/DriftPass.c
+++ b/atintegrators/DriftPass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 

--- a/atintegrators/EAperturePass.c
+++ b/atintegrators/EAperturePass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+
 
 static void markaslost(double *r6,int idx)
 {

--- a/atintegrators/IdentityPass.c
+++ b/atintegrators/IdentityPass.c
@@ -3,7 +3,7 @@
    Revision 7/16/03
    A.Terebilo terebilo@slac.stanford.edu
 */
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 

--- a/atintegrators/Matrix66Pass.c
+++ b/atintegrators/Matrix66Pass.c
@@ -4,7 +4,7 @@
    A.Terebilo terebilo@ssrl.slac.stanford.edu
 */
 
-#include "at.h"
+#include "atelem.c"
 #include "atlalib.c"
 
 void Matrix66Pass(double *r, const double *M,

--- a/atintegrators/MatrixTijkPass.c
+++ b/atintegrators/MatrixTijkPass.c
@@ -3,7 +3,7 @@
 */
 
 
-#include "at.h"
+#include "atelem.c"
 #include "atlalib.c"
 
 static void ATmultTijk(double *r, const double* T)

--- a/atintegrators/QuadLinearFPass.c
+++ b/atintegrators/QuadLinearFPass.c
@@ -6,7 +6,7 @@
 */
 
 
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 

--- a/atintegrators/QuadLinearPass.c
+++ b/atintegrators/QuadLinearPass.c
@@ -4,7 +4,7 @@
    A.Terebilo terebilo@ssrl.slac.stanford.edu
 */
 
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 #include <math.h>

--- a/atintegrators/QuadMPoleFringePass.c
+++ b/atintegrators/QuadMPoleFringePass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 #include "driftkick.c"		/* fastdrift.c, strthinkick.c */

--- a/atintegrators/QuadMPoleFringeRadPass.c
+++ b/atintegrators/QuadMPoleFringeRadPass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 #include "driftkickrad.c"	/* drift6.c, strthinkickrad.c */

--- a/atintegrators/QuantDiffPass.c
+++ b/atintegrators/QuantDiffPass.c
@@ -1,7 +1,8 @@
+#include "at.h"
 #include "atelem.c"
 #include <time.h>
 #include <math.h>
-#if !(defined PCWIN || defined PCWIN32 || defined PCWIN64)
+#if !(defined PCWIN || defined PCWIN32 || defined PCWIN64 || defined _WIN32)
 #include <sys/time.h>
 #endif
 #ifndef M_PI
@@ -42,7 +43,7 @@ void QuantDiffPass(double *r_in, double* Lmatp , int Seed, int nturn, int num_pa
   }
   else if(initSeed)
   {
-#if !(defined PCWIN || defined PCWIN32 || defined PCWIN64)
+#if !(defined PCWIN || defined PCWIN32 || defined PCWIN64 || defined _WIN32)
       {
       struct timeval time;
       gettimeofday(&time,NULL);
@@ -96,8 +97,10 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
 {
     int nturn=Param->nturn;
     if (!Elem) {
-        double *Lmatp=atGetDoubleArray(ElemData,"Lmatp"); check_error();
-        int Seed=atGetOptionalLong(ElemData,"Seed",0); check_error();
+        double *Lmatp;
+        int Seed;
+        Lmatp=atGetDoubleArray(ElemData,"Lmatp"); check_error();
+        Seed=atGetOptionalLong(ElemData,"Seed",0); check_error();
         Elem = (struct elem*)atMalloc(sizeof(struct elem));
         Elem->Lmatp=Lmatp;
         Elem->Seed=Seed;   
@@ -105,6 +108,9 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     QuantDiffPass(r_in, Elem->Lmatp, Elem->Seed, nturn, num_particles);
     return Elem;
 }
+
+void initQuantDiffPass(void) {};
+
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
 #if defined(MATLAB_MEX_FILE)

--- a/atintegrators/RFCavityPass.c
+++ b/atintegrators/RFCavityPass.c
@@ -6,7 +6,7 @@
  */
 
 #include <math.h>
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 #define TWOPI  6.28318530717959

--- a/atintegrators/SolenoidLinearPass.c
+++ b/atintegrators/SolenoidLinearPass.c
@@ -4,7 +4,7 @@
    A.Terebilo terebilo@slac.stanford.edu
 */
 
-#include "at.h"
+#include "atelem.c"
 #include "atlalib.c"
 
 

--- a/atintegrators/StrMPoleSymplectic4Pass.c
+++ b/atintegrators/StrMPoleSymplectic4Pass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 

--- a/atintegrators/StrMPoleSymplectic4RadPass.c
+++ b/atintegrators/StrMPoleSymplectic4RadPass.c
@@ -1,4 +1,4 @@
-#include "at.h"
+
 #include "atelem.c"
 #include "atlalib.c"
 

--- a/atintegrators/ThinMPolePass.c
+++ b/atintegrators/ThinMPolePass.c
@@ -3,7 +3,7 @@
    A.Terebilo terebilo@ssrl.slac.stanford.edu
 */
 
-#include "at.h"
+#include "atelem.c"
 #include "atlalib.c"
 #include "driftkick.c"
 

--- a/atintegrators/WiggLinearPass.c
+++ b/atintegrators/WiggLinearPass.c
@@ -1,4 +1,5 @@
-#include "at.h"
+
+#include "atelem.c"
 #include "atlalib.c"
 
 

--- a/atintegrators/at.h
+++ b/atintegrators/at.h
@@ -4,20 +4,7 @@
 #include <math.h>
 #include "attypes.h"
 
-#if defined(_WIN32)  /*Windows*/
-#include <Windows.h>
-#define isnan(x) _isnan(x)
-#define isinf(x) (!_finite(x))
-#define isfinite(x) _finite(x)
-/* See https://blogs.msdn.microsoft.com/oldnewthing/20100305-00/?p=14713 */
-DECLSPEC_SELECTANY extern const float FLOAT_NaN = ((float)((1e308 * 10)*0.));
-#define NAN FLOAT_NaN
-DECLSPEC_SELECTANY extern const float FLOAT_POSITIVE_INFINITY = ((float)(1e308 * 10));
-#define INFINITY FLOAT_POSITIVE_INFINITY
-typedef int bool;
-#define false 0
-#define true 1
-#elif !defined(MATLAB_MEX_FILE) /*Linux*/
+#if !defined(MATLAB_MEX_FILE) /*Linux*/
 #include <stdbool.h>
 #ifndef INFINITY
 static const double pinf = 1.0 / 0.0;

--- a/atintegrators/atelem.c
+++ b/atintegrators/atelem.c
@@ -9,22 +9,6 @@
 #define ExportMode
 #endif
 
-#if defined(_WIN32)
-#include <Windows.h>
-#define isnan(x) _isnan(x)
-#define isinf(x) (!_finite(x))
-#define isfinite(x) _finite(x)
-/* See https://blogs.msdn.microsoft.com/oldnewthing/20100305-00/?p=14713 */
-DECLSPEC_SELECTANY extern const float FLOAT_NaN = ((float)((1e308 * 10)*0.));
-#define NAN FLOAT_NaN
-DECLSPEC_SELECTANY extern const float FLOAT_POSITIVE_INFINITY = ((float)(1e308 * 10));
-#define INFINITY FLOAT_POSITIVE_INFINITY
-typedef int bool;
-#define false 0
-#define true 1
-#else
-#include <stdbool.h>
-#endif /*_WIN32*/
 
 #if defined(MATLAB_MEX_FILE)
 
@@ -99,6 +83,22 @@ static void *atCalloc(size_t count, size_t size)
 #include <numpy/ndarrayobject.h>
 #include <stdlib.h>
 
+#if defined(_WIN32) /*Python on Windows*/
+#include <Windows.h>
+#define isnan(x) _isnan(x)
+#define isinf(x) (!_finite(x))
+#define isfinite(x) _finite(x)
+/* See https://blogs.msdn.microsoft.com/oldnewthing/20100305-00/?p=14713 */
+DECLSPEC_SELECTANY extern const float FLOAT_NaN = ((float)((1e308 * 10)*0.));
+#define NAN FLOAT_NaN
+DECLSPEC_SELECTANY extern const float FLOAT_POSITIVE_INFINITY = ((float)(1e308 * 10));
+#define INFINITY FLOAT_POSITIVE_INFINITY
+typedef int bool;
+#define false 0
+#define true 1
+#else /*Python not on Windows*/
+#include <stdbool.h>
+#endif /*_WIN32*/
 
 #if PY_MAJOR_VERSION >= 3
 #define NUMPY_IMPORT_ARRAY_RETVAL NULL

--- a/atintegrators/atelem.c
+++ b/atintegrators/atelem.c
@@ -9,6 +9,23 @@
 #define ExportMode
 #endif
 
+#if defined(_WIN32)
+#include <Windows.h>
+#define isnan(x) _isnan(x)
+#define isinf(x) (!_finite(x))
+#define isfinite(x) _finite(x)
+/* See https://blogs.msdn.microsoft.com/oldnewthing/20100305-00/?p=14713 */
+DECLSPEC_SELECTANY extern const float FLOAT_NaN = ((float)((1e308 * 10)*0.));
+#define NAN FLOAT_NaN
+DECLSPEC_SELECTANY extern const float FLOAT_POSITIVE_INFINITY = ((float)(1e308 * 10));
+#define INFINITY FLOAT_POSITIVE_INFINITY
+typedef int bool;
+#define false 0
+#define true 1
+#else
+#include <stdbool.h>
+#endif /*_WIN32*/
+
 #if defined(MATLAB_MEX_FILE)
 
 #include <mex.h>


### PR DESCRIPTION
I realise there is still a problem with `at.h`.

There is one more problem to compile on Windows:  `mexErrMsgIdAndText` and `mexErrMsgTxt` in `IdTablePass.c` and `interpolate.c`.  I'm not sure how best to replace these.