### PR TITLE
Python3 on Windows

### DIFF
--- a/atintegrators/AperturePass.c
+++ b/atintegrators/AperturePass.c
@@ -37,7 +37,8 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return Elem;
 }
 
-void initAperturePass(void) {};
+MODULE_DEF(AperturePass)        /* Dummy module initialisation */
+
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
 #if defined(MATLAB_MEX_FILE)

--- a/atintegrators/BendLinearPass.c
+++ b/atintegrators/BendLinearPass.c
@@ -247,7 +247,8 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         return(Elem);
 }
 
-void initBendLinearPass(void) {};
+MODULE_DEF(BendLinearPass)        /* Dummy module initialisation */
+
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
 #if defined(MATLAB_MEX_FILE)

--- a/atintegrators/BndMPoleSymplectic2RadQEPass.c
+++ b/atintegrators/BndMPoleSymplectic2RadQEPass.c
@@ -263,8 +263,7 @@ void BndMPoleSymplectic4RadPass(double *r, double le, double irho, double *A, do
 			}
 }
 
-
-void initBndMPoleSymplectic2RadQEPass(void) {};
+MODULE_DEF(BndMPoleSymplectic2RadQEPass)        /* Dummy module initialisation */
 
 #ifdef MATLAB_MEX_FILE
 

--- a/atintegrators/BndMPoleSymplectic4E2Pass.c
+++ b/atintegrators/BndMPoleSymplectic4E2Pass.c
@@ -348,7 +348,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return Elem;
 }
 
-void initBndMPoleSymplectic4E2Pass(void) {};
+MODULE_DEF(BndMPoleSymplectic4E2Pass)        /* Dummy module initialisation */
 
 #endif /*MATLAB_MEX_FILE || PYAT*/
 

--- a/atintegrators/BndMPoleSymplectic4E2RadPass.c
+++ b/atintegrators/BndMPoleSymplectic4E2RadPass.c
@@ -340,7 +340,7 @@ void BndMPoleSymplectic4E2RadPass(double *r, double le, double irho, double *A, 
 			}
 }
 
-void initBndMPoleSymplectic4E2RadPass(void) {};
+MODULE_DEF(BndMPoleSymplectic4E2RadPass)        /* Dummy module initialisation */
 
 #ifdef MATLAB_MEX_FILE
 

--- a/atintegrators/BndMPoleSymplectic4FrgFPass.c
+++ b/atintegrators/BndMPoleSymplectic4FrgFPass.c
@@ -155,7 +155,8 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return Elem;
 }
 
-void initBndMPoleSymplectic4FrgFPass(void) {};
+MODULE_DEF(BndMPoleSymplectic4FrgFPass)        /* Dummy module initialisation */
+
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
 #if defined(MATLAB_MEX_FILE)

--- a/atintegrators/BndMPoleSymplectic4FrgFRadPass.c
+++ b/atintegrators/BndMPoleSymplectic4FrgFRadPass.c
@@ -154,7 +154,8 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return Elem;
 }
 
-void initBndMPoleSymplectic4FrgFRadPass(void) {};
+MODULE_DEF(BndMPoleSymplectic4FrgFRadPass)        /* Dummy module initialisation */
+
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
 #if defined(MATLAB_MEX_FILE)

--- a/atintegrators/BndMPoleSymplectic4Pass.c
+++ b/atintegrators/BndMPoleSymplectic4Pass.c
@@ -200,8 +200,8 @@ void BndMPoleSymplectic4Pass(double *r, double le, double irho, double *A, doubl
 			}
 }
 
-void initBndMPoleSymplectic4Pass(void) {};
-    	
+MODULE_DEF(BndMPoleSymplectic4Pass)        /* Dummy module initialisation */
+
 #ifdef MATLAB_MEX_FILE
 
 #include "elempass.h"

--- a/atintegrators/BndMPoleSymplectic4RadPass.c
+++ b/atintegrators/BndMPoleSymplectic4RadPass.c
@@ -248,7 +248,7 @@ void BndMPoleSymplectic4RadPass(double *r, double le, double irho, double *A, do
 			}
 }
 
-void initBndMPoleSymplectic4RadPass(void) {};
+MODULE_DEF(BndMPoleSymplectic4RadPass)        /* Dummy module initialisation */
 
 #ifdef MATLAB_MEX_FILE
 

--- a/atintegrators/CavityPass.c
+++ b/atintegrators/CavityPass.c
@@ -83,7 +83,8 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return Elem;
 }
 
-void initCavityPass(void) {};
+MODULE_DEF(CavityPass)        /* Dummy module initialisation */
+
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
 #if defined(MATLAB_MEX_FILE)

--- a/atintegrators/CorrectorPass.c
+++ b/atintegrators/CorrectorPass.c
@@ -41,7 +41,7 @@ void CorrectorPass(double *r_in, double xkick, double ykick, double len,  int nu
 		}	
 }
 
-void initCorrectorPass(void) {};
+MODULE_DEF(CorrectorPass)        /* Dummy module initialisation */
 
 #ifdef MATLAB_MEX_FILE
 

--- a/atintegrators/DeltaQPass.c
+++ b/atintegrators/DeltaQPass.c
@@ -73,7 +73,7 @@ void DeltaQPass(double *r_in, int num_particles, double alphax, double alphay,
     }
 }
 
-void initDeltaQPass(void) {};
+MODULE_DEF(DeltaQPass)        /* Dummy module initialisation */
 
 #ifdef MATLAB_MEX_FILE
 

--- a/atintegrators/DriftPass.c
+++ b/atintegrators/DriftPass.c
@@ -83,7 +83,8 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return Elem;
 }
 
-void initDriftPass(void) {};
+MODULE_DEF(DriftPass)        /* Dummy module initialisation */
+
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
 #if defined(MATLAB_MEX_FILE)

--- a/atintegrators/EAperturePass.c
+++ b/atintegrators/EAperturePass.c
@@ -22,7 +22,7 @@ void EAperturePass(double *r_in, double *axesptr, int num_particles)
     }
 }
 
-void initEAperturePass(void) {};
+MODULE_DEF(EAperturePass)        /* Dummy module initialisation */
 
 #ifdef MATLAB_MEX_FILE
 

--- a/atintegrators/IdTablePass.c
+++ b/atintegrators/IdTablePass.c
@@ -147,7 +147,7 @@ void IdKickMapModelPass(double *r, double le, double *xkick1, double *ykick1, do
     }
 }
 
-void initIdTablePass(void) {};
+MODULE_DEF(IdTablePass)        /* Dummy module initialisation */
 
 #ifdef MATLAB_MEX_FILE
 

--- a/atintegrators/IdentityPass.c
+++ b/atintegrators/IdentityPass.c
@@ -66,7 +66,9 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
             Elem->RApertures,Elem->EApertures,num_particles);
     return Elem;
 }
-void initIdentityPass(void) {};
+
+MODULE_DEF(IdentityPass)        /* Dummy module initialisation */
+
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
 #if defined(MATLAB_MEX_FILE)

--- a/atintegrators/Matrix66Pass.c
+++ b/atintegrators/Matrix66Pass.c
@@ -27,7 +27,7 @@ void Matrix66Pass(double *r, const double *M,
 	}
 }
 
-void initMatrix66Pass(void) {};
+MODULE_DEF(Matrix66Pass)        /* Dummy module initialisation */
 
 #ifdef MATLAB_MEX_FILE
 

--- a/atintegrators/MatrixTijkPass.c
+++ b/atintegrators/MatrixTijkPass.c
@@ -48,7 +48,7 @@ void MatrixTijkPass(double *r, const double *M, const double *Tijk,
 	}
 }
 
-void initMatrixTijkPass(void) {};
+MODULE_DEF(MatrixTijkPass)        /* Dummy module initialisation */
 
 #ifdef MATLAB_MEX_FILE
 

--- a/atintegrators/QuadLinearFPass.c
+++ b/atintegrators/QuadLinearFPass.c
@@ -186,7 +186,8 @@ void QuadLinearFPass(double *r, double le, double kv, double I1a, double I1b,dou
 		}		
 }
 
-void initQuadLinearFPass(void) {};
+MODULE_DEF(QuadLinearFPass)        /* Dummy module initialisation */
+
 
 /********** END PHYSICS SECTION ***********************************************/
 /******************************************************************************/

--- a/atintegrators/QuadLinearPass.c
+++ b/atintegrators/QuadLinearPass.c
@@ -134,7 +134,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return(Elem);
 }
 
-void initQuadLinearPass(void) {};
+MODULE_DEF(QuadLinearPass)        /* Dummy module initialisation */
 
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 

--- a/atintegrators/QuadMPoleFringePass.c
+++ b/atintegrators/QuadMPoleFringePass.c
@@ -194,7 +194,8 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return Elem;
 }
 
-void initQuadMPoleFringePass(void) {};
+MODULE_DEF(QuadMPoleFringePass)        /* Dummy module initialisation */
+
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
 #if defined(MATLAB_MEX_FILE)

--- a/atintegrators/QuadMPoleFringeRadPass.c
+++ b/atintegrators/QuadMPoleFringeRadPass.c
@@ -193,7 +193,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return Elem;
 }
 
-void initQuadMPoleFringeRadPass(void) {};
+MODULE_DEF(QuadMPoleFringeRadPass)        /* Dummy module initialisation */
 
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 

--- a/atintegrators/QuantDiffPass.c
+++ b/atintegrators/QuantDiffPass.c
@@ -107,7 +107,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return Elem;
 }
 
-void initQuantDiffPass(void) {};
+MODULE_DEF(QuantDiffPass)        /* Dummy module initialisation */
 
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 

--- a/atintegrators/RFCavityPass.c
+++ b/atintegrators/RFCavityPass.c
@@ -90,7 +90,8 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return Elem;
 }
 
-void initRFCavityPass(void) {};
+MODULE_DEF(RFCavityPass)        /* Dummy module initialisation */
+
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
 #if defined(MATLAB_MEX_FILE)

--- a/atintegrators/SolenoidLinearPass.c
+++ b/atintegrators/SolenoidLinearPass.c
@@ -86,7 +86,7 @@ void SolenoidLinearPass(double *r_in, double le, double ks, double *T1, double *
 		}
 }
 
-void initSolenoidLinearPass(void) {};
+MODULE_DEF(SolenoidLinearPass)        /* Dummy module initialisation */
 
 #ifdef MATLAB_MEX_FILE
 

--- a/atintegrators/StrMPoleSymplectic4Pass.c
+++ b/atintegrators/StrMPoleSymplectic4Pass.c
@@ -183,7 +183,8 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return Elem;
 }
 
-void initStrMPoleSymplectic4Pass(void) {};
+MODULE_DEF(StrMPoleSymplectic4Pass)        /* Dummy module initialisation */
+
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
 #if defined(MATLAB_MEX_FILE)

--- a/atintegrators/StrMPoleSymplectic4RadPass.c
+++ b/atintegrators/StrMPoleSymplectic4RadPass.c
@@ -237,7 +237,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     return Elem;
 }
 
-void initStrMPoleSymplectic4RadPass(void) {};
+MODULE_DEF(StrMPoleSymplectic4RadPass)        /* Dummy module initialisation */
 
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 

--- a/atintegrators/ThinMPolePass.c
+++ b/atintegrators/ThinMPolePass.c
@@ -31,7 +31,7 @@ void ThinMPolePass(double *r, double *A, double *B, int max_order,
     }
 }
 
-void initThinMPolePass(void) {};
+MODULE_DEF(ThinMPolePass)        /* Dummy module initialisation */
 
 #ifdef MATLAB_MEX_FILE
 

--- a/atintegrators/WiggLinearPass.c
+++ b/atintegrators/WiggLinearPass.c
@@ -79,7 +79,7 @@ void WiggLinearPass(double *r, double le, double invrho, double kxkz, double *T1
    }
 }
 
-void initWiggLinearPass(void) {};
+MODULE_DEF(WiggLinearPass)        /* Dummy module initialisation */
 
 /********** END PHYSICS SECTION ***********************************************/
 /******************************************************************************/

--- a/atintegrators/at.h
+++ b/atintegrators/at.h
@@ -19,5 +19,3 @@
 #endif
 
 #endif /*AT_H*/
-
-

--- a/atintegrators/atcommon.h
+++ b/atintegrators/atcommon.h
@@ -1,6 +1,34 @@
 #ifndef ATCOMMON_H
 #define ATCOMMON_H
 
+#ifdef PYAT
+/* Python.h must be included first. */
+#include <Python.h>
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/ndarrayobject.h>
+
+#if PY_MAJOR_VERSION >= 3
+#define MOD_INIT(name) PyMODINIT_FUNC PyInit_##name(void)
+#define MOD_ERROR_VAL NULL
+#define NUMPY_IMPORT_ARRAY_RETVAL NULL
+#define NUMPY_IMPORT_ARRAY_TYPE void *
+#else
+#define MOD_INIT(name) PyMODINIT_FUNC init##name(void)
+#define MOD_ERROR_VAL
+#define NUMPY_IMPORT_ARRAY_RETVAL
+#define NUMPY_IMPORT_ARRAY_TYPE void
+#define PyLong_AsLong PyInt_AsLong
+#endif
+#if defined(_WIN32)    /* Create a dummy module initialisation function for Windows */
+#define MODULE_DEF(name) MOD_INIT(name) {return MOD_ERROR_VAL;}
+#endif /* _WIN32 */
+#endif /* PYAT */
+
+#ifndef MODULE_DEF
+#define MODULE_DEF(name)
+#endif
+
 /* All builds */
 #include <stdlib.h>
 #include <math.h>
@@ -23,6 +51,7 @@
 #if defined(_WIN32) && (_MSC_VER < 1800)
 /* Python Windows builds */
 #include <Windows.h>
+#include <float.h>
 #define isnan(x) _isnan(x)
 #define isinf(x) (!_finite(x))
 #define isfinite(x) _finite(x)

--- a/atintegrators/atelem.c
+++ b/atintegrators/atelem.c
@@ -5,11 +5,6 @@
 #ifndef ATELEM_C
 #define ATELEM_C
 
-#ifdef PYAT
-/* Python.h must be included first. */
-#include <Python.h>
-#endif /*PYAT*/
-
 #include "atcommon.h"
 
 /*----------------------------------------------------*/
@@ -106,18 +101,6 @@ static double* atGetOptionalDoubleArray(const mxArray *ElemData, const char *fie
 
 #if defined(PYAT)
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/ndarrayobject.h>
-
-#if PY_MAJOR_VERSION >= 3
-#define NUMPY_IMPORT_ARRAY_RETVAL NULL
-#define NUMPY_IMPORT_ARRAY_TYPE void *
-#else
-#define NUMPY_IMPORT_ARRAY_RETVAL
-#define NUMPY_IMPORT_ARRAY_TYPE void
-#define PyLong_AsLong PyInt_AsLong
-#endif
-
 typedef PyObject atElem;
 #define check_error() if (PyErr_Occurred()) return NULL
 
@@ -212,4 +195,5 @@ ExportMode struct elem *trackFunction(const atElem *ElemData, struct elem *Elem,
                                       int num_particles, struct parameters *Param);
 
 #endif /* defined(PYAT) || defined(MATLAB_MEX_FILE) */
+
 #endif /*ATELEM_C*/


### PR DESCRIPTION
Set a fake module initialisation function in each integrator so that:
- it appears only on Windows
- its signature is compatible with both Python2 and Python3

(I finally got a test a Windows test machine with both Python version)